### PR TITLE
Better solution/project layout without polluting repo with local dev settings

### DIFF
--- a/Source/RimworldInstall.props
+++ b/Source/RimworldInstall.props
@@ -1,0 +1,8 @@
+  <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	  <PropertyGroup>
+      <!-- change this to local installation path to enable assembly lookups (UnityEngine & base game) -->
+		  <RimworldInstallPath>..\..\..\RimWorld</RimworldInstallPath>		
+      <!-- If you're developing on a non windows machine, change to correct path-->
+		  <RimworldDataPath>$(RimworldInstallPath)\RimWorldWin_Data\</RimworldDataPath>
+	  </PropertyGroup>
+  </Project>

--- a/Source/StorageSearch.csproj
+++ b/Source/StorageSearch.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(SolutionDir)\RimworldInstall.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -57,17 +58,13 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\RimWorldWin_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(RimworldDataPath)\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.XML" />
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\RimWorldWin_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(RimworldDataPath)\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Source/StorageSearch.sln
+++ b/Source/StorageSearch.sln
@@ -5,6 +5,11 @@ VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StorageSearch", "StorageSearch.csproj", "{E6445749-9D93-42AE-92ED-4761B9D2D72C}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Dev Settings", "Dev Settings", "{E97DB748-B86F-4A4B-B040-F3FEEA6BEAA1}"
+	ProjectSection(SolutionItems) = preProject
+		RimworldInstall.props = RimworldInstall.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
Here pull request No 2 😉 

Current project has _your_ local path to _your_ Rimworld installation directory (or at least to a copy of it's managed assemblies) hard-coded into the project.
This leads to noise if someone else develops on the project who had to change this, since his/her local setup differs.

I've moved the lookup (hint) path for the Rimworld assemblies to an external (easily editable) file _which also does not track changes in git (So if a dozen different devs have a dozen different local values the repo does not check those dozen settings back in as changes).*_

---
* [Skip worktree](https://git-scm.com/docs/git-update-index#_skip_worktree_bit) is set on the `RimworldInstall.props` file.